### PR TITLE
Rename fields and paths

### DIFF
--- a/pushlog_scanner.py
+++ b/pushlog_scanner.py
@@ -85,8 +85,8 @@ async def main(args):
     os.environ['TC_CACHE_DIR'] = config['TC_CACHE_DIR']
 
     cost_dataframe_columns = ['project', 'product', 'groupid',
-                              'pushid', 'date', 'origin', 'totalcost', 'idealcost']
-    daily_dataframe_columns = ['project', 'product', 'date', 'origin', 'totalcost', 'taskcount']
+                              'pushid', 'graph_date', 'origin', 'totalcost', 'idealcost']
+    daily_dataframe_columns = ['project', 'product', 'ci_date', 'origin', 'totalcost', 'taskcount']
 
     args['short_project'] = args['project'].split('/')[-1]
     config['pushlog_cache_file'] = config['pushlog_cache_file'].format(

--- a/scanner.yml.example
+++ b/scanner.yml.example
@@ -3,4 +3,4 @@ pushlog_cache_file: 's3://mozilla-releng-metrics/measuring_ci/pushlog_cache_{pro
 costs_csv_file: 's3://mozilla-releng-metrics/measuring_ci/aws_cost_estimates.csv'
 TC_CACHE_DIR: 's3://mozilla-releng-metrics/taskgraph_cache/'
 total_cost_output: 's3://mozilla-releng-metrics/measuring_ci/v1/costs.parquet'
-daily_totals_output: 's3://mozilla-releng-metrics/measuring_ci/v1/daily_totals.parquet'
+daily_totals_output: 's3://mozilla-releng-metrics/measuring_ci/daily_totals/v1/daily_totals.parquet'


### PR DESCRIPTION
'date' is a function, and also causes errors when reusing it across different tables.
Renamed to be unique, until a better option is there.

Have also changed the path for daily totals, to avoid Glue Crawler issues with it merging
schema.