### PR TITLE
Backfill support

### DIFF
--- a/pushlog_scanner.py
+++ b/pushlog_scanner.py
@@ -93,6 +93,7 @@ async def scan_project(project, product, config):
                                 project=project,
                                 product=product,
                                 # starting_push=34612,
+                                backfill_count=config['backfill_count'],
                                 cache_file=config['pushlog_cache_file'])
 
     try:
@@ -196,6 +197,7 @@ async def main(args):
     with open(args['config'], 'r') as y:
         config = yaml.load(y)
     os.environ['TC_CACHE_DIR'] = config['TC_CACHE_DIR']
+    config['backfill_count'] = args.get('backfill_count', None)
 
     # cope with original style, listing one project, or listing multiple
     for project in args.get('projects', [args.get('project')]):


### PR DESCRIPTION
Add support for reading a backfill_count parameter from the trigger args, and use that to process that many older pushes into the data store. This lets us backfill on AWS Lambda (instead of locally) by using the Test button on the console.