### PR TITLE
Examine nightlies and releases

### DIFF
--- a/create_lambda_func.sh
+++ b/create_lambda_func.sh
@@ -16,16 +16,10 @@ OUTPUT_FILENAME="$(pwd)/measuring_ci.zip"
 
 mkdir -p "${STAGING_DIR}"
 
-cp -pr "pushlog_scanner.py" "${STAGING_DIR}/lambda_function.py"
+cp -pr "pushlog_scanner.py" "${STAGING_DIR}/"
+cp -pr "releases_scanner.py" "${STAGING_DIR}/"
 
-cp -p "scanner.yml" "${STAGING_DIR}/scanner.yml"
-
-if ! grep -q "def lambda_handler" "${STAGING_DIR}/lambda_function.py"
-then
-    echo ""
-    echo "*** No lambda_handler function found, remember to set the handler when uploading the zip file."
-    echo ""
-fi
+cp -p *.yml "${STAGING_DIR}/"
 
 cp -pr "measuring_ci" "${STAGING_DIR}"
 
@@ -75,7 +69,7 @@ echo "2. Visit https://console.aws.amazon.com/lambda/home?region=us-east-1#/func
 echo "ARN - arn:aws:lambda:us-east-1:314336048151:function:measuring_ci_parquet_update"
 echo "3. Under 'Function code' choose a 'Code entry type' of 'Upload a file from Amazon S3'"
 echo "Paste the above s3 url into the box"
-echo "4. Ensure the Handler is set correctly if not using lambda_handler() in lambda_function.py"
+echo "4. Ensure the Handler is set correctly if not using lambda_function:lambda_handler()"
 echo "5. Under 'Basic Settings' ensure the Memory usage is at 512Mb and Timeout is at least 2 minutes."
 echo "6. Click 'Save' at the top of the page"
 

--- a/measuring_ci/nightly.py
+++ b/measuring_ci/nightly.py
@@ -11,7 +11,8 @@ log = logging.getLogger()
 def sanitize_date(date):
     """Attempt to sanitize a date format.
 
-    Should ideally cope with epoch and also validate strings."""
+    Should ideally cope with epoch and also validate strings.
+    """
     if isinstance(date, datetime):
         return date.strftime("%Y.%m.%d")
     return date

--- a/measuring_ci/nightly.py
+++ b/measuring_ci/nightly.py
@@ -1,0 +1,78 @@
+import asyncio
+import logging
+from datetime import datetime
+
+import taskcluster
+import yaml
+
+log = logging.getLogger()
+
+
+def sanitize_date(date):
+    """Attempt to sanitize a date format.
+
+    Should ideally cope with epoch and also validate strings."""
+    if isinstance(date, datetime):
+        return date.strftime("%Y.%m.%d")
+    return date
+
+
+async def fetch_nightlies(date, project='mozilla-central'):
+    """Fetch nightly task group IDs by date."""
+    index = "gecko.v2.{project}.nightly.{date}.revision"
+
+    index = index.format(
+        project=project.split('/')[-1],  # remove paths like release/ integration/
+        date=sanitize_date(date),
+    )
+
+    idx = taskcluster.aio.Index()
+    queue = taskcluster.aio.Queue()
+
+    ret = await idx.listNamespaces(index)
+
+    revision_namespaces = [n['namespace'] for n in ret['namespaces']]
+
+    tasks = [asyncio.ensure_future(idx.listNamespaces(n)) for n in revision_namespaces]
+    ret = await asyncio.gather(*tasks)
+    product_namespaces = [n['namespace'] for m in ret for n in m.get('namespaces', [])]
+
+    # -l10n namespaces are filtered out here as they have another namespace layer
+    # underneath, not tasks.
+    tasks = [asyncio.ensure_future(idx.listTasks(n)) for n in product_namespaces]
+    ret = await asyncio.gather(*tasks)
+    build_tasks = list()
+    for platform in ret:
+        if not platform.get('tasks'):
+            continue
+        # All of the platforms within a product should have tasks
+        # that fall under the same task group ID, so we can just
+        # get the first one and use that.
+        build_tasks.append(platform['tasks'][0]['namespace'])
+
+    results = dict()
+    for task in build_tasks:
+        log.debug('Looking for taskId via task %s', task)
+        try:
+            build_task = await idx.findTask(task)
+            task_def = await queue.task(build_task['taskId'])
+            revision, product = task.split('.')[-3:-1]
+            results[task_def['taskGroupId']] = {
+                'product': product,
+                'revision': revision,
+            }
+            # Find the version, hidden in the parameters of the
+            # decision task's artifacts
+            sync_queue = taskcluster.Queue()
+            parameters_response = sync_queue.getLatestArtifact(taskId=task_def['taskGroupId'], name='public/parameters.yml')
+            # print(parameters_response)
+
+            parameters = yaml.load(parameters_response['response'].text)
+            # async variant
+            # parameters = yaml.loads(await parameters_response['response'].text())
+            results[task_def['taskGroupId']]['version'] = parameters.get('app_version', '')
+
+        except taskcluster.exceptions.TaskclusterRestFailure as e:
+            log.warning(e)
+
+    return results

--- a/measuring_ci/releasewarrior.py
+++ b/measuring_ci/releasewarrior.py
@@ -1,0 +1,109 @@
+"""
+Utilities for reading release graph data from ReleaseWarrior
+
+https://github.com/mozilla-releng/releasewarrior-data
+
+Lots of assumptions here about the directory structure inside releasewarrior-data.
+"""
+import glob
+import json
+import os
+from datetime import datetime
+
+from sh import git
+
+
+def clone_releasewarrior_data(dest_path="releasewarrior-data"):
+    """Clone the releasewarrior-data repository.
+
+    We're not interested in the history, so limit the depth of the clone.
+    """
+    if not dest_path.startswith('/'):
+        dest_path = os.path.join(os.getcwd(), dest_path)
+    if os.path.exists(dest_path):
+        if os.path.exists(os.path.join(dest_path, '.git')):
+            git('-C', dest_path, 'pull')
+        else:
+            raise ValueError('Path exists and is not a git repository: {}'.format(dest_path))
+    else:
+        git('clone', '--depth', '10', 'https://github.com/mozilla-releng/releasewarrior-data', dest_path)
+    return dest_path
+
+
+def fetch_release_data(json_path):
+    """Extract useful fields from a releasewarrior data file."""
+    with open(json_path) as f:
+        release_data = json.load(f)
+
+    # print("release_data[version]: ", release_data['version'])
+    # version = FirefoxVersion.parse(release_data['version'])
+    version = release_data['version']
+    product = release_data['product']
+
+    unknown_phase = 'Unknown'  # For when no graph type is recorded.
+
+    graphs = dict()
+    if 'inflight' in release_data:
+        # RW-2 format
+        for build in release_data['inflight']:
+            if not build['graphids']:
+                continue
+            if isinstance(build['graphids'][0], list):
+                # Newest style, graphs are a list of ['phase', 'id']
+                for graph in build['graphids']:
+                    graphs[graph[1]] = {
+                        'product': product,
+                        'version': version,
+                        'phase': graph[0],
+                        'build_number': build.get('buildnum', 1)
+                    }
+            else:
+                # graphids are a flat list of graphs
+                for graph in build['graphids']:
+                    graphs[graph] = {
+                        'product': product,
+                        'version': version,
+                        'phase': unknown_phase,
+                        'build_number': build.get('buildnum', 1)
+                    }
+    elif 'builds' in release_data:
+        # Older RW-1 format.
+        for build in release_data['builds']:
+            if 'graphid' in build:
+                graphs[build['graphid']] = {
+                    'product': product,
+                    'version': version,
+                    'phase': unknown_phase,
+                    'build_number': build.get('buildnum', 1)
+                }
+    else:
+        raise NotImplementedError('Expected to have a search feature')
+
+    return graphs
+
+
+def read_release_taskgraph_ids(repo_path, since=None):
+    """Find releasewarrior data files.
+
+    Args:
+        repo_path (str): Path to clone of releasewarrior-data repository.
+        since (str|datetime): How much of the git history to examine. Default: all.
+    """
+    glob_files = list()
+    for path in glob.glob("{}/inflight/**/*.json".format(repo_path)) + glob.glob("{}/archive/**/*.json".format(repo_path)):
+        glob_files.append(path)
+
+    if since:
+        if isinstance(since, datetime):
+            since = since.strftime("%Y-%m-%d")
+        git_out = git('--no-pager', '-C', repo_path, 'log',
+                      '--since="{}"'.format(since), '--name-only', '--pretty=format:')
+        git_files = [os.path.join(repo_path, g) for g in git_out.splitlines()]
+        paths = set(git_files) & set(glob_files)
+    else:
+        paths = glob_files
+
+    graphs = dict()
+    for path in paths:
+        graphs.update(fetch_release_data(path))
+    return graphs

--- a/measuring_ci/releasewarrior.py
+++ b/measuring_ci/releasewarrior.py
@@ -1,5 +1,5 @@
 """
-Utilities for reading release graph data from ReleaseWarrior
+Utilities for reading release graph data from ReleaseWarrior.
 
 https://github.com/mozilla-releng/releasewarrior-data
 
@@ -55,7 +55,7 @@ def fetch_release_data(json_path):
                         'product': product,
                         'version': version,
                         'phase': graph[0],
-                        'build_number': build.get('buildnum', 1)
+                        'build_number': build.get('buildnum', 1),
                     }
             else:
                 # graphids are a flat list of graphs
@@ -64,7 +64,7 @@ def fetch_release_data(json_path):
                         'product': product,
                         'version': version,
                         'phase': unknown_phase,
-                        'build_number': build.get('buildnum', 1)
+                        'build_number': build.get('buildnum', 1),
                     }
     elif 'builds' in release_data:
         # Older RW-1 format.
@@ -74,7 +74,7 @@ def fetch_release_data(json_path):
                     'product': product,
                     'version': version,
                     'phase': unknown_phase,
-                    'build_number': build.get('buildnum', 1)
+                    'build_number': build.get('buildnum', 1),
                 }
     else:
         raise NotImplementedError('Expected to have a search feature')

--- a/nightlies.yml.example
+++ b/nightlies.yml.example
@@ -1,0 +1,4 @@
+costs_csv_file: 's3://mozilla-releng-metrics/measuring_ci/aws_cost_estimates.csv'
+costs_scriptworker_csv_file: 's3://mozilla-releng-metrics/measuring_ci/aws_cost_estimates_scriptworker.csv'
+TC_CACHE_DIR: 's3://mozilla-releng-metrics/taskgraph_cache/'
+total_cost_output: 's3://mozilla-releng-metrics/measuring_ci/v2/costs/nightlies.parquet'

--- a/releases.yml.example
+++ b/releases.yml.example
@@ -1,0 +1,6 @@
+costs_csv_file: 's3://mozilla-releng-metrics/measuring_ci/aws_cost_estimates.csv'
+costs_scriptworker_csv_file: 's3://mozilla-releng-metrics/measuring_ci/aws_cost_estimates_scriptworker.csv'
+TC_CACHE_DIR: 's3://mozilla-releng-metrics/taskgraph_cache/'
+total_cost_output: 's3://mozilla-releng-metrics/measuring_ci/v2/costs/releases.parquet'
+releasewarrior-data-path: './releasewarrior-data'
+since: '6 days ago'

--- a/releases_scanner.py
+++ b/releases_scanner.py
@@ -1,0 +1,151 @@
+import argparse
+import asyncio
+import copy
+import logging
+import os
+
+import pandas as pd
+import yaml
+
+from measuring_ci.costs import fetch_all_worker_costs, taskgraph_cost
+from measuring_ci.releasewarrior import clone_releasewarrior_data, read_release_taskgraph_ids
+from taskhuddler.aio.graph import TaskGraph
+
+LOG_LEVEL = logging.INFO
+
+# AWS artisinal log handling, they've already set up a handler by the time we get here
+log = logging.getLogger()
+log.setLevel(LOG_LEVEL)
+# some modules are very chatty
+logging.getLogger("taskcluster").setLevel(logging.INFO)
+logging.getLogger("aiohttp").setLevel(logging.INFO)
+
+
+def parse_args():
+    """Extract arguments."""
+    parser = argparse.ArgumentParser(description="CI Costs")
+    parser.add_argument('--config', type=str, default='releases.yml')
+    return parser.parse_args()
+
+
+async def _semaphore_wrapper(action, args, semaphore):
+    """Wrap an async function with semaphores."""
+    async with semaphore:
+        return await action(*args)
+
+
+def categorize_version(product, version):
+    """Return a descriptive string of the release type.
+
+    Perhaps this should be in mozilla_version"""
+    if product == 'devedition':
+        return product
+    elif 'b' in version:
+        return 'beta'
+    elif 'a' in version:
+        return 'nightly'
+    elif 'esr' in version:
+        return 'esr'
+    return 'release'
+
+
+async def scan_releases(config, repo_path):
+    """Scan recent history for complete task graphs."""
+    config = copy.deepcopy(config)
+    cost_dataframe_columns = [
+        'product', 'groupid',
+        'graph_date', 'category',
+        'phase', 'version', 'build_number',
+        'totalcost', 'idealcost', 'taskcount',
+    ]
+
+    if not config['total_cost_output'].startswith('/'):
+        config['total_cost_output'] = os.path.join(os.getcwd(), config['total_cost_output'])
+
+    try:
+        existing_costs = pd.read_parquet(config['total_cost_output'])
+        log.info("Loaded existing release costs")
+    except Exception:
+        log.info("Couldn't load existing release costs, using empty data set")
+        existing_costs = pd.DataFrame(columns=cost_dataframe_columns)
+
+    log.info("Looking up taskgraph IDs")
+    taskgraph_ids = read_release_taskgraph_ids(repo_path, config.get('since'))
+    log.info("Found %d taskgraph IDs", len(taskgraph_ids))
+
+    tasks = list()
+    semaphore = asyncio.Semaphore(10)
+
+    for graph_id in taskgraph_ids:
+        if str(graph_id) in existing_costs['groupid'].values:
+            log.debug("Already examined taskgroup %s, skipping.", graph_id)
+            continue
+        tasks.append(asyncio.ensure_future(
+            _semaphore_wrapper(
+                TaskGraph,
+                args=(graph_id,),
+                semaphore=semaphore,
+            )))
+
+    log.info('Gathering task %d graphs', len(tasks))
+    taskgraphs = await asyncio.gather(*tasks)
+
+    costs = list()
+
+    log.info('Calculating costs')
+    worker_costs = fetch_all_worker_costs(
+        tc_csv_filename=config['costs_csv_file'],
+        scriptworker_csv_filename=config.get('costs_scriptworker_csv_file'),
+    )
+    for graph in taskgraphs:
+        full_cost, final_runs_cost = taskgraph_cost(graph, worker_costs)
+        product = taskgraph_ids[graph.groupid]['product']
+        version = taskgraph_ids[graph.groupid]['version'].replace('rc', '')
+
+        costs.append(
+            [
+                product,
+                graph.groupid,
+                graph.earliest_start_time.strftime("%Y-%m-%d"),  # date bucket
+                categorize_version(product, version),
+                taskgraph_ids[graph.groupid]['phase'],
+                version,
+                taskgraph_ids[graph.groupid]['build_number'],
+                full_cost,
+                final_runs_cost,
+                len([t for t in graph.tasks()]),  # task count
+            ])
+
+    costs_df = pd.DataFrame(costs, columns=cost_dataframe_columns)
+
+    new_costs = existing_costs.merge(costs_df, how='outer')
+    log.info("Writing parquet file %s", config['total_cost_output'])
+    new_costs.to_parquet(config['total_cost_output'], compression='gzip')
+
+
+async def main(args):
+    """Main program."""
+    with open(args['config'], 'r') as cfg:
+        config = yaml.load(cfg)
+    os.environ['TC_CACHE_DIR'] = config['TC_CACHE_DIR']
+    config['backfill_count'] = args.get('backfill_count', None)
+
+    # the path gets fully qualified
+    repo_path = clone_releasewarrior_data(config['releasewarrior-data-path'])
+
+    await scan_releases(config, repo_path)
+
+
+def lambda_handler(args, context):
+    """AWS Lambda entry point."""
+    assert context  # not currently used
+    if 'config' not in args:
+        args['config'] = 'releases.yml'
+    loop = asyncio.get_event_loop()
+    loop.run_until_complete(main(args))
+
+
+if __name__ == '__main__':
+    logging.basicConfig(level=LOG_LEVEL)
+    # Use command-line arguments instead of json blob if not running in AWS Lambda
+    lambda_handler(vars(parse_args()), {'dummy': 1})

--- a/releases_scanner.py
+++ b/releases_scanner.py
@@ -37,7 +37,8 @@ async def _semaphore_wrapper(action, args, semaphore):
 def categorize_version(product, version):
     """Return a descriptive string of the release type.
 
-    Perhaps this should be in mozilla_version"""
+    Perhaps this should be in mozilla_version
+    """
     if product == 'devedition':
         return product
     elif 'b' in version:


### PR DESCRIPTION
Use releasewarrior data to examine releases, and record extra
fields such as phase.

Use taskcluster index to search for yesterday's nightlies, and
record appropriate data.

The intention here is that it all gets packaged up into one .zip
for lambda use, which we can then send to multiple different
lambda functions, and just configure a different handler function
for each one.