### PR TITLE
adds upstream taskhuddler repo to reqs

### DIFF
--- a/requirements/main.in
+++ b/requirements/main.in
@@ -9,7 +9,7 @@ boto3
 s3fs
 pyyaml
 # Taskhuddler is required but not yet available as a package
-# -e git+https://github.com/srfraser/taskhuddler#egg=taskhuddler
+# -e git+https://github.com/mozilla-releng/taskhuddler#egg=taskhuddler
 
 # Required by taskhuddler
 asyncinit

--- a/requirements/taskhuddler.txt
+++ b/requirements/taskhuddler.txt
@@ -1,1 +1,1 @@
--e git+https://github.com/srfraser/taskhuddler#egg=taskhuddler
+-e git+https://github.com/mozilla-releng/taskhuddler#egg=taskhuddler


### PR DESCRIPTION
I suspect we need: https://github.com/mozilla-releng/taskhuddler/commit/17fcdfa02f3d3f0e01261311c3360c7a8b4b70cb

Just as measuring-ci needed the following itself: https://github.com/mozilla-releng/measuring_ci/commit/e0b9b5a0b5cb5a134b80e5f7192e9efc56e2cfc4

λ python ./releases_scanner.py                                                                                       master [2cbf798] modified
INFO:root:Loaded existing release costs
INFO:root:Looking up taskgraph IDs
INFO:root:Found 302 taskgraph IDs
INFO:root:Gathering 22 task graphs
Traceback (most recent call last):
  File "./releases_scanner.py", line 148, in <module>
    lambda_handler(vars(parse_args()), {'dummy': 1})
  File "./releases_scanner.py", line 142, in lambda_handler
    loop.run_until_complete(main(args))
  File "/usr/local/Cellar/python/3.7.0/Frameworks/Python.framework/Versions/3.7/lib/python3.7/asyncio/base_events.py", line 568, in run_until_c
omplete
    return future.result()
  File "./releases_scanner.py", line 133, in main
    await scan_releases(config)
  File "./releases_scanner.py", line 89, in scan_releases
    taskgraphs = await asyncio.gather(*tasks)
  File "./releases_scanner.py", line 34, in _semaphore_wrapper
    return await action(*args)
  File "/Users/jlund/venvs/measure-ci/lib/python3.7/site-packages/asyncinit/__init__.py", line 51, in new
    await cls_init(*args, **kwargs)
  File "/Users/jlund/venvs/measure-ci/src/taskhuddler/taskhuddler/aio/graph.py", line 30, in __init__
    await self.fetch_tasks()
  File "/Users/jlund/venvs/measure-ci/src/taskhuddler/taskhuddler/aio/graph.py", line 56, in fetch_tasks
    queue = Queue(session=session)
  File "/Users/jlund/venvs/measure-ci/lib/python3.7/site-packages/taskcluster/aio/asyncclient.py", line 68, in __init__
    super(AsyncBaseClient, self).__init__(*args, **kwargs)
  File "/Users/jlund/venvs/measure-ci/lib/python3.7/site-packages/taskcluster/client.py", line 63, in __init__
    raise exceptions.TaskclusterFailure('rootUrl option is required')
taskcluster.exceptions.TaskclusterFailure: rootUrl option is required